### PR TITLE
Add actions write permission to publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
     - name: Download


### PR DESCRIPTION
Testing adding `actions: write` permission to see if publish download artifact task will work.