### PR TITLE
Add PlatyPS generated markdown for help

### DIFF
--- a/PoshJsonWebToken.build.ps1
+++ b/PoshJsonWebToken.build.ps1
@@ -40,6 +40,12 @@ task Publish {
     }
 }
 
+task Docs {
+    $docsPath = Join-Path -Path $PSScriptRoot -ChildPath 'docs' -AdditionalChildPath 'en-US'
+    $outputPath = Join-Path -Path $ReleasePath -ChildPath 'en-US'
+    New-ExternalHelp -Path $docsPath -OutputPath $outputPath | Out-Null
+}
+
 task Package {
     $nupkgPath = Join-Path -Path $BuildPath -ChildPath "$ModuleName.$ModuleVersion.nupkg"
     if (Test-Path -Path $nupkgPath) {
@@ -91,7 +97,7 @@ task RunPesterTests {
     Invoke-Pester -Configuration $configuration
 }
 
-task Build -Jobs Clean, Publish, Package
+task Build -Jobs Clean, Publish, Docs, Package
 
 task Test -Jobs Publish, RunPesterTests
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Another PowerShell module for generating and validating JWT tokens.
 While there are a few other JWT PowerShell modules on the gallery this module includes the following features:
 
 + Broad hash algorithm support:
-  + HS256
-  + HS384
-  + HS512
-  + RS256
-  + RS384
-  + RS512
-  + ES256
-  + ES384
-  + ES512
+  + `HS256` - HMAC with SHA-256
+  + `HS384` - HMAC with SHA-384
+  + `HS512` - HMAC with SHA-512
+  + `RS256` - RSA Signature with SHA-256
+  + `RS384` - RSA Signature with SHA-384
+  + `RS512` - RSA Signature with SHA-512
+  + `ES256` - P-256 curve and SHA-256
+  + `ES384` - P-384 curve and SHA-384
+  + `ES512` - P-512 curve and SHA-512
 
 + Uses the ultimate [`jose-jwt`](https://www.nuget.org/packages/jose-jwt/) nuget package to get a wide variety of builtin JWT support into PowerShell.
 
@@ -36,7 +36,7 @@ $secretKey = 'abc' | ConvertTo-SecureString -AsPlainText -Force
 $algorithm = 'HS256'
 
 # Generate JWT token
-$token = New-JsonWebToken -Payload $Payload -Algorithm $algorithm -SecretKey $SecretKey -ExtraHeader $ExtraHeader
+$token = New-JsonWebToken -Payload $Payload -Algorithm $algorithm -SecretKey $SecretKey -ExtraHeader $header
 
 # Validate JWT token
 Test-JsonWebToken -Token $token -SecretKey $SecretKey -Algorithm $algorithm
@@ -53,7 +53,7 @@ $certificatePath = Resolve-Path -Path 'cert.p12'
 $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($certificatePath)
 
 # Generate JWT token
-$token = New-JsonWebToken -Payload $Payload -Algorithm $algorithm -Certificate $certificate -ExtraHeader $ExtraHeader
+$token = New-JsonWebToken -Payload $Payload -Algorithm $algorithm -Certificate $certificate -ExtraHeader $header
 
 # Validate JWT token
 Test-JsonWebToken -Token $token -Certificate $certificate -Algorithm $algorithm

--- a/docs/en-US/New-JsonWebToken.md
+++ b/docs/en-US/New-JsonWebToken.md
@@ -1,0 +1,186 @@
+---
+external help file: PoshJsonWebToken.dll-Help.xml
+Module Name: PoshJsonWebToken
+online version:
+schema: 2.0.0
+---
+
+# New-JsonWebToken
+
+## SYNOPSIS
+
+Creates a signed Json Web Token (JWT).
+
+## SYNTAX
+
+### SecretKey
+
+```powershell
+New-JsonWebToken -Payload <Hashtable> -Algorithm <JwsAlgorithm> [-ExtraHeader <Hashtable>]
+ -SecretKey <SecureString> [<CommonParameters>]
+```
+
+### Certificate
+
+```powershell
+New-JsonWebToken -Payload <Hashtable> -Algorithm <JwsAlgorithm> [-ExtraHeader <Hashtable>]
+ -Certificate <X509Certificate2> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `New-JsonWebToken` cmdlet can be used to create a new Json Web Token (JWT) using a secret key or certificate.
+
+The following symmetric hash algorithms support secret key:
+
++ `HS256` - HMAC with SHA-256
++ `HS384` - HMAC with SHA-384
++ `HS512` - HMAC with SHA-512
+
+The following asymmetric hash algorithms support certificates:
+
++ `RS256` - RSA Signature with SHA-256
++ `RS384` - RSA Signature with SHA-384
++ `RS512` - RSA Signature with SHA-512
++ `ES256` - P-256 curve and SHA-256
++ `ES384` - P-384 curve and SHA-384
++ `ES512` - P-512 curve and SHA-512
+
+The above algorithms have their advantages and disadvantages, depending on the use case and the level of security required.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+$payload = @{ 'a' = 'b' }
+$header = @{ 'exp' = 1300819380 }
+$secretKey = 'abc' | ConvertTo-SecureString -AsPlainText -Force
+$algorithm = 'HS256'
+
+# Generate JWT token
+$token = New-JsonWebToken -Payload $Payload -Algorithm $algorithm -SecretKey $SecretKey -ExtraHeader $header
+```
+
+Creating a HS256 JWT token using secret key.
+
+### Example 2
+
+```powershell
+$payload = @{ 'a' = 'b' }
+$header = @{ 'exp' = 1300819380 }
+$algorithm = 'RS256'
+
+$certificatePath = Resolve-Path -Path 'cert.p12'
+$certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($certificatePath)
+
+# Generate JWT token
+$token = New-JsonWebToken -Payload $Payload -Algorithm $algorithm -Certificate $certificate -ExtraHeader $header
+```
+
+Creating a RS256 JWT token using certificate.
+
+## PARAMETERS
+
+### -Algorithm
+
+The hash algorithm.
+Currently PS256, PS384 and PS512 algorithms are not supported.
+
+```yaml
+Type: JwsAlgorithm
+Parameter Sets: (All)
+Aliases:
+Accepted values: none, HS256, HS384, HS512, RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Certificate
+
+The signing certificate of type `System.Security.Cryptography.X509Certificates.X509Certificate2`.
+Must be specified and contain the private key if the algorithm is RS256, RS384, RS512, ES256, ES384 or ES512.
+
+```yaml
+Type: X509Certificate2
+Parameter Sets: Certificate
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExtraHeader
+
+The extra headers needed to sign JWT token.
+These headers are not including the `alg` header which is passed using `-Algorithm` parameter.
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Payload
+
+The payload containing the claims to sign.
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SecretKey
+
+The HMAC secret secret key.
+Must be specified if the algorithm is HS256, HS384 or HS512.
+
+```yaml
+Type: SecureString
+Parameter Sets: SecretKey
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Security.SecureString
+
+Output is secured so Json Web Token (JWT) encrypyted string is not exposed.
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/en-US/Test-JsonWebToken.md
+++ b/docs/en-US/Test-JsonWebToken.md
@@ -1,0 +1,176 @@
+---
+external help file: PoshJsonWebToken.dll-Help.xml
+Module Name: PoshJsonWebToken
+online version:
+schema: 2.0.0
+---
+
+# Test-JsonWebToken
+
+## SYNOPSIS
+
+Tests Json Web Token (JWT) is valid.
+
+## SYNTAX
+
+### SecretKey
+
+```powershell
+Test-JsonWebToken -Token <SecureString> -Algorithm <JwsAlgorithm> -SecretKey <SecureString>
+ [<CommonParameters>]
+```
+
+### Certificate
+
+```powershell
+Test-JsonWebToken -Token <SecureString> -Algorithm <JwsAlgorithm> -Certificate <X509Certificate2>
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Test-JsonWebToken` cmdlet can be used to ensure Json Web Token (JWT) is valid.
+
+The following symmetric hash algorithms support secret key:
+
++ `HS256` - HMAC with SHA-256
++ `HS384` - HMAC with SHA-384
++ `HS512` - HMAC with SHA-512
+
+The following asymmetric hash algorithms support certificates:
+
++ `RS256` - RSA Signature with SHA-256
++ `RS384` - RSA Signature with SHA-384
++ `RS512` - RSA Signature with SHA-512
++ `ES256` - P-256 curve and SHA-256
++ `ES384` - P-384 curve and SHA-384
++ `ES512` - P-512 curve and SHA-512
+
+The above algorithms ensures *strict validation* is performed on the Json Web Token (JWT).
+This means that you will specify which algorithm you are expecting to receive in the header.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+$payload = @{ 'a' = 'b' }
+$header = @{ 'exp' = 1300819380 }
+$secretKey = 'abc' | ConvertTo-SecureString -AsPlainText -Force
+$algorithm = 'HS256'
+
+# Generate JWT token
+$token = New-JsonWebToken -Payload $Payload -Algorithm $algorithm -SecretKey $SecretKey -ExtraHeader $header
+
+# Validate JWT token
+Test-JsonWebToken -Token $token -SecretKey $SecretKey -Algorithm $algorithm
+```
+
+Validates signed JWT token using secret key and HS256 algorithm.
+
+### Example 2
+
+```powershell
+$payload = @{ 'a' = 'b' }
+$header = @{ 'exp' = 1300819380 }
+$algorithm = 'RS256'
+
+$certificatePath = Resolve-Path -Path 'cert.p12'
+$certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($certificatePath)
+
+# Generate JWT token
+$token = New-JsonWebToken -Payload $Payload -Algorithm $algorithm -Certificate $certificate -ExtraHeader $header
+
+# Validate JWT token
+Test-JsonWebToken -Token $token -Certificate $certificate -Algorithm $algorithm
+```
+
+Validates signed JWT token using certificate and RS256 algorithm.
+
+## PARAMETERS
+
+### -Algorithm
+
+The hash algorithm.
+Currently PS256, PS384 and PS512 algorithms are not supported.
+
+```yaml
+Type: JwsAlgorithm
+Parameter Sets: (All)
+Aliases:
+Accepted values: none, HS256, HS384, HS512, RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Certificate
+
+The signing certificate of type `System.Security.Cryptography.X509Certificates.X509Certificate2`.
+Must be specified and contain the private key if the algorithm is RS256, RS384, RS512, ES256, ES384 or ES512.
+
+```yaml
+Type: X509Certificate2
+Parameter Sets: Certificate
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SecretKey
+
+The HMAC secret secret key.
+Must be specified if the algorithm is HS256, HS384 or HS512.
+
+```yaml
+Type: SecureString
+Parameter Sets: SecretKey
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Token
+
+The signed JWT token to validate.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Boolean
+
+If JWT token is valid this cmdlet returns `True`, otherwise an exception is thrown and the cmdlet returns `False`.
+
+## NOTES
+
+## RELATED LINKS

--- a/requirements-dev.psd1
+++ b/requirements-dev.psd1
@@ -1,4 +1,5 @@
 @{
-    "InvokeBuild" = "5.10.4"
-    "Pester" = "5.5.0"
+    InvokeBuild = "5.10.4"
+    Pester      = "5.5.0"
+    platyPS     = '0.14.2'
 }


### PR DESCRIPTION
Included the following:

- New `docs/en-US` folder for markdown files
- Generated markdown using `platyPS` module.
- Changed `README` to include more specifics on hash algorithms.