### PR TITLE
Add support for generating unprotected tokens

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,27 +4,27 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-      {
-        "name": "PowerShell: Interactive Session",
-        "type": "PowerShell",
-        "request": "launch",
-        "cwd": "${workspaceRoot}"
-      },
-      {
-        "name": "Debug PoshJsonWebToken Cmdlets",
-        "type": "coreclr",
-        "request": "launch",
-        "preLaunchTask": "Build",
-        "program": "pwsh",
-        "args": [
-          "-NoExit",
-          "-NoProfile",
-          "-Command",
-          "Import-Module ${workspaceFolder}/out/PoshJsonWebToken/PoshJsonWebToken.psd1",
-        ],
-        "cwd": "${workspaceFolder}",
-        "stopAtEntry": false,
-        "console": "integratedTerminal"
-      }
+        {
+            "name": "PowerShell: Interactive Session",
+            "type": "PowerShell",
+            "request": "launch",
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "name": "Debug PoshJsonWebToken Cmdlets",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build",
+            "program": "pwsh",
+            "args": [
+                "-NoExit",
+                "-NoProfile",
+                "-Command",
+                "Import-Module ${workspaceFolder}/out/PoshJsonWebToken/",
+            ],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "integratedTerminal"
+        }
     ]
-  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "editor.tabSize": 4,
     "editor.insertSpaces": true,
     "editor.formatOnSave": true,
+    "editor.detectIndentation": false,
     "[yaml]": {
         "editor.tabSize": 2,
     },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,20 +4,14 @@
     "version": "2.0.0",
     "tasks": [
         {
-          "label": "Build",
-          "type": "shell",
-          "command": "& ./build.ps1 -Configuration Debug",
-          "group": {
-            "kind": "build",
-            "isDefault": true
-          },
-          "problemMatcher": "$msCompile"
-        },
-        {
-          "label": "CleanBuild",
-          "type": "shell",
-          "command": "& ./build.ps1 -Configuration Debug -Clean",
-          "problemMatcher": "$msCompile"
+            "label": "Build",
+            "type": "shell",
+            "command": "& ./build.ps1",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/docs/en-US/New-JsonWebToken.md
+++ b/docs/en-US/New-JsonWebToken.md
@@ -86,6 +86,7 @@ Creating a RS256 JWT token using certificate.
 
 The hash algorithm.
 Currently PS256, PS384 and PS512 algorithms are not supported.
+If `none` is used, a warning message is displayed indicating plain text algorithm is used without integrity protection.
 
 ```yaml
 Type: JwsAlgorithm

--- a/docs/en-US/New-JsonWebToken.md
+++ b/docs/en-US/New-JsonWebToken.md
@@ -27,6 +27,13 @@ New-JsonWebToken -Payload <Hashtable> -Algorithm <JwsAlgorithm> [-ExtraHeader <H
  -Certificate <X509Certificate2> [<CommonParameters>]
 ```
 
+### None
+
+```powershell
+New-JsonWebToken -Payload <Hashtable> -Algorithm <JwsAlgorithm> [-ExtraHeader <Hashtable>]
+ [<CommonParameters>]
+```
+
 ## DESCRIPTION
 
 The `New-JsonWebToken` cmdlet can be used to create a new Json Web Token (JWT) using a secret key or certificate.

--- a/docs/en-US/Test-JsonWebToken.md
+++ b/docs/en-US/Test-JsonWebToken.md
@@ -93,6 +93,7 @@ Validates signed JWT token using certificate and RS256 algorithm.
 
 The hash algorithm.
 Currently PS256, PS384 and PS512 algorithms are not supported.
+If `none` is used, a warning message is displayed indicating plain text algorithm is used without integrity protection.
 
 ```yaml
 Type: JwsAlgorithm

--- a/docs/en-US/Test-JsonWebToken.md
+++ b/docs/en-US/Test-JsonWebToken.md
@@ -27,6 +27,13 @@ Test-JsonWebToken -Token <SecureString> -Algorithm <JwsAlgorithm> -Certificate <
  [<CommonParameters>]
 ```
 
+### None
+
+```powershell
+New-JsonWebToken -Payload <Hashtable> -Algorithm <JwsAlgorithm> [-ExtraHeader <Hashtable>]
+ [<CommonParameters>]
+```
+
 ## DESCRIPTION
 
 The `Test-JsonWebToken` cmdlet can be used to ensure Json Web Token (JWT) is valid.

--- a/src/Commands/JsonWebTokenBaseCommand.cs
+++ b/src/Commands/JsonWebTokenBaseCommand.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Jose;
 using PoshJsonWebToken.Common;
+using PoshJsonWebToken.Resources;
 
 namespace PoshJsonWebToken.Commands;
 
@@ -15,8 +16,9 @@ public abstract class JsonWebTokenCommandBase : PSCmdlet
 {
     #region Parameter Sets
 
-    private const string SecretKeyParameterSet = "SecretKey";
-    private const string CertificateParameterSet = "Certificate";
+    protected const string NoneParameterSet = "None";
+    protected const string SecretKeyParameterSet = "SecretKey";
+    protected const string CertificateParameterSet = "Certificate";
 
     #endregion Parameter Sets
 
@@ -45,9 +47,22 @@ public abstract class JsonWebTokenCommandBase : PSCmdlet
     /// <returns>The signing key object.</returns>
     protected object GetTokenSigningKey(JwsAlgorithm algorithm)
     {
-        var algorithmFamily = AlgorithmHelpers.GetAlgorithmFamily(algorithm);
-
         object key = null;
+
+        if (ParameterSetName.Equals(NoneParameterSet, StringComparison.OrdinalIgnoreCase))
+        {
+            if (algorithm == JwsAlgorithm.none)
+            {
+                WriteWarning(AlgorithmStrings.NoneAlgorithmWarning);
+                return key;
+            }
+            else
+            {
+                AlgorithmHelpers.ReportAlgorithmWithoutKey(this, algorithm);
+            }
+        }
+
+        var algorithmFamily = AlgorithmHelpers.GetAlgorithmFamily(algorithm);
 
         if (ParameterSetName.Equals(SecretKeyParameterSet, StringComparison.OrdinalIgnoreCase))
         {

--- a/src/Commands/New-JsonWebToken.cs
+++ b/src/Commands/New-JsonWebToken.cs
@@ -16,19 +16,25 @@ public sealed class NewJsonWebTokenCommand : JsonWebTokenCommandBase
     /// <summary>
     /// The payload to encode into JWT token.
     /// </summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = SecretKeyParameterSet)]
+    [Parameter(Mandatory = true, ParameterSetName = CertificateParameterSet)]
+    [Parameter(Mandatory = true, ParameterSetName = NoneParameterSet)]
     public Hashtable Payload { get; set; }
 
     /// <summary>
     /// The hash algorithm used to encode JWT token.
     /// </summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = SecretKeyParameterSet)]
+    [Parameter(Mandatory = true, ParameterSetName = CertificateParameterSet)]
+    [Parameter(Mandatory = true, ParameterSetName = NoneParameterSet)]
     public JwsAlgorithm Algorithm { get; set; }
 
     /// <summary>
     /// The extra headers used to encode JWT token.
     /// </summary>
-    [Parameter(Mandatory = false)]
+    [Parameter(Mandatory = false, ParameterSetName = SecretKeyParameterSet)]
+    [Parameter(Mandatory = false, ParameterSetName = CertificateParameterSet)]
+    [Parameter(Mandatory = false, ParameterSetName = NoneParameterSet)]
     public Hashtable ExtraHeader { get; set; }
 
     #endregion Parameters

--- a/src/Commands/Test-JsonWebToken.cs
+++ b/src/Commands/Test-JsonWebToken.cs
@@ -17,13 +17,17 @@ public sealed class TestJsonWebTokenCommand : JsonWebTokenCommandBase
     /// <summary>
     /// The JWT token to decode.
     /// </summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = SecretKeyParameterSet)]
+    [Parameter(Mandatory = true, ParameterSetName = CertificateParameterSet)]
+    [Parameter(Mandatory = true, ParameterSetName = NoneParameterSet)]
     public SecureString Token { get; set; }
 
     /// <summary>
     /// The hash algorithm used to encode JWT token.
     /// </summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = SecretKeyParameterSet)]
+    [Parameter(Mandatory = true, ParameterSetName = CertificateParameterSet)]
+    [Parameter(Mandatory = true, ParameterSetName = NoneParameterSet)]
     public JwsAlgorithm Algorithm { get; set; }
 
     #endregion Parameters

--- a/src/Common/AlgorithmHelpers.cs
+++ b/src/Common/AlgorithmHelpers.cs
@@ -76,4 +76,21 @@ internal static class AlgorithmHelpers
             certificate);
         cmdlet.ThrowTerminatingError(errorRecord);
     }
+
+    /// <summary>
+    /// Throws an exception if algorithm is used without key.
+    /// </summary>
+    /// <param name="cmdlet">The cmdlet.</param>
+    /// <param name="algorithm">The hash algorithm.</param>
+    internal static void ReportAlgorithmWithoutKey(PSCmdlet cmdlet, JwsAlgorithm algorithm)
+    {
+        var errorMessage = string.Format(AlgorithmStrings.AlgorithmRequiresKey, algorithm);
+        var exception = new ArgumentException(errorMessage);
+        var errorRecord = new ErrorRecord(
+            exception,
+            nameof(AlgorithmStrings.AlgorithmRequiresKey),
+            ErrorCategory.InvalidArgument,
+            algorithm);
+        cmdlet.ThrowTerminatingError(errorRecord);
+    }
 }

--- a/src/Resources/AlgorithmStrings.Designer.cs
+++ b/src/Resources/AlgorithmStrings.Designer.cs
@@ -8,11 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PoshJsonWebToken.Resources
-{
+namespace PoshJsonWebToken.Resources {
     using System;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,70 +22,76 @@ namespace PoshJsonWebToken.Resources
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class AlgorithmStrings
-    {
-
+    internal class AlgorithmStrings {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal AlgorithmStrings()
-        {
+        internal AlgorithmStrings() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if (object.ReferenceEquals(resourceMan, null))
-                {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PoshJsonWebToken.resources.AlgorithmStrings", typeof(AlgorithmStrings).Assembly);
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PoshJsonWebToken.Resources.AlgorithmStrings", typeof(AlgorithmStrings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The algorithm &apos;{0}&apos; requires a key using -SecretKey or -Certificate parameters..
+        /// </summary>
+        internal static string AlgorithmRequiresKey {
+            get {
+                return ResourceManager.GetString("AlgorithmRequiresKey", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Certificate parameter requires any one of &apos;{0}&apos; algorithms..
-        /// /// </summary>
-        internal static string CertificateRequiredAlgorithms
-        {
-            get
-            {
+        /// </summary>
+        internal static string CertificateRequiredAlgorithms {
+            get {
                 return ResourceManager.GetString("CertificateRequiredAlgorithms", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using NONE (unprotected) plain text algorithm without integrity protection..
+        /// </summary>
+        internal static string NoneAlgorithmWarning {
+            get {
+                return ResourceManager.GetString("NoneAlgorithmWarning", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Secret parameter requires any one of &apos;{0}&apos; algorithms..
         /// </summary>
-        internal static string SecretRequiredAlgorithms
-        {
-            get
-            {
+        internal static string SecretRequiredAlgorithms {
+            get {
                 return ResourceManager.GetString("SecretRequiredAlgorithms", resourceCulture);
             }
         }

--- a/src/Resources/AlgorithmStrings.Designer.cs
+++ b/src/Resources/AlgorithmStrings.Designer.cs
@@ -8,10 +8,11 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PoshJsonWebToken.Resources {
+namespace PoshJsonWebToken.Resources
+{
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -22,76 +23,92 @@ namespace PoshJsonWebToken.Resources {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class AlgorithmStrings {
-        
+    internal class AlgorithmStrings
+    {
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal AlgorithmStrings() {
+        internal AlgorithmStrings()
+        {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PoshJsonWebToken.Resources.AlgorithmStrings", typeof(AlgorithmStrings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The algorithm &apos;{0}&apos; requires a key using -SecretKey or -Certificate parameters..
         /// </summary>
-        internal static string AlgorithmRequiresKey {
-            get {
+        internal static string AlgorithmRequiresKey
+        {
+            get
+            {
                 return ResourceManager.GetString("AlgorithmRequiresKey", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Certificate parameter requires any one of &apos;{0}&apos; algorithms..
         /// </summary>
-        internal static string CertificateRequiredAlgorithms {
-            get {
+        internal static string CertificateRequiredAlgorithms
+        {
+            get
+            {
                 return ResourceManager.GetString("CertificateRequiredAlgorithms", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Using NONE (unprotected) plain text algorithm without integrity protection..
         /// </summary>
-        internal static string NoneAlgorithmWarning {
-            get {
+        internal static string NoneAlgorithmWarning
+        {
+            get
+            {
                 return ResourceManager.GetString("NoneAlgorithmWarning", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Secret parameter requires any one of &apos;{0}&apos; algorithms..
         /// </summary>
-        internal static string SecretRequiredAlgorithms {
-            get {
+        internal static string SecretRequiredAlgorithms
+        {
+            get
+            {
                 return ResourceManager.GetString("SecretRequiredAlgorithms", resourceCulture);
             }
         }

--- a/src/Resources/AlgorithmStrings.resx
+++ b/src/Resources/AlgorithmStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -122,5 +122,11 @@
   </data>
   <data name="SecretRequiredAlgorithms" xml:space="preserve">
     <value>Secret parameter requires any one of '{0}' algorithms.</value>
+  </data>
+  <data name="NoneAlgorithmWarning" xml:space="preserve">
+    <value>Using NONE (unprotected) plain text algorithm without integrity protection.</value>
+  </data>
+  <data name="AlgorithmRequiresKey" xml:space="preserve">
+    <value>The algorithm '{0}' requires a key using -SecretKey or -Certificate parameters.</value>
   </data>
 </root>

--- a/test/JsonWebToken.Tests.ps1
+++ b/test/JsonWebToken.Tests.ps1
@@ -6,58 +6,57 @@ Describe 'JsonWebToken Tests' {
     BeforeDiscovery {
         $payload = @{ 'a' = 'b' }
         $header = @{ 'exp' = 1300819380 }
+        $secretKey = 'abc' | ConvertTo-SecureString -AsPlainText -Force
     }
 
     Context 'HS Family Algorithms' {
-        BeforeDiscovery {
-            $secretKey = 'abc' | ConvertTo-SecureString -AsPlainText -Force
-        }
 
         It "<Title>" -TestCases @(
             @{
-                Payload = $payload
-                Algorithm = 'HS256'
-                SecretKey = $secretKey
+                Payload       = $payload
+                Algorithm     = 'HS256'
+                SecretKey     = $secretKey
                 ExpectedToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.N1LLr2A9h9deCX5riFKcQ52LkHsb7v6sUktK3py94Jo'
-                Title = 'Should return expected JWT token using HS256 algorithm and secret key with no headers'
+                Title         = 'Should return expected JWT token using HS256 algorithm and secret key with no headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'HS256'
-                SecretKey = $secretKey
+                Payload       = $payload
+                Algorithm     = 'HS256'
+                SecretKey     = $secretKey
                 ExpectedToken = 'eyJhbGciOiJIUzI1NiIsImV4cCI6MTMwMDgxOTM4MH0.eyJhIjoiYiJ9.Pfvplu00vAoSuhS4JQ7sBUcN4nBUNseb2PDTJXqpObA'
-                ExtraHeader = $header
-                Title = 'Should return expected JWT token using HS256 algorithm and secret key with headers'
+                ExtraHeader   = $header
+                Title         = 'Should return expected JWT token using HS256 algorithm and secret key with headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'HS384'
-                SecretKey = $secretKey
+                Payload       = $payload
+                Algorithm     = 'HS384'
+                SecretKey     = $secretKey
                 ExpectedToken = 'eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.AW7rys56-2Mqb5WErxivswynIFYOOZYm_2r-tY3HgoWOgvdg3dd3f6757a3sUtEK'
-                Title = 'Should return expected JWT token using HS384 algorithm and secret key with no headers'
+                Title         = 'Should return expected JWT token using HS384 algorithm and secret key with no headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'HS384'
-                SecretKey = $secretKey
+                Payload       = $payload
+                Algorithm     = 'HS384'
+                SecretKey     = $secretKey
                 ExpectedToken = 'eyJhbGciOiJIUzM4NCIsImV4cCI6MTMwMDgxOTM4MH0.eyJhIjoiYiJ9.xUNP90Pt_POh9NNK12h_FikZZnToKa5yo5a8tYpiaCUcT7f5ob7rezpfdAm3A0Ck'
-                ExtraHeader = $header
-                Title = 'Should return expected JWT token using HS384 algorithm and secret key with headers'
+                ExtraHeader   = $header
+                Title         = 'Should return expected JWT token using HS384 algorithm and secret key with headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'HS512'
-                SecretKey = $secretKey
+                Payload       = $payload
+                Algorithm     = 'HS512'
+                SecretKey     = $secretKey
                 ExpectedToken = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.M-SylZTDUXqiL_4iuaJ-B0eUEevXygIoAs9_NsyKrSBUrsTzmUYSfUq0QoPlTt6iOclGFJn1E4_eRMcpoI5x1g'
-                Title = 'Should return expected JWT token using HS512 algorithm and secret key with no headers'
+                Title         = 'Should return expected JWT token using HS512 algorithm and secret key with no headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'HS512'
-                SecretKey = $secretKey
+                Payload       = $payload
+                Algorithm     = 'HS512'
+                SecretKey     = $secretKey
                 ExpectedToken = 'eyJhbGciOiJIUzUxMiIsImV4cCI6MTMwMDgxOTM4MH0.eyJhIjoiYiJ9.u-_coYrXkFjqdmasRWJWQJIRKbbHDS9lzOOKO30q-0ZzrNnVCC10CY8vUQPl0-darlxiFzCSB9bNiACTgN1Y0Q'
-                ExtraHeader = $header
-                Title = 'Should return expected JWT token using HS512 algorithm and secret key with headers' }
+                ExtraHeader   = $header
+                Title         = 'Should return expected JWT token using HS512 algorithm and secret key with headers'
+            }
         ) {
             param($Payload, $Algorithm, $SecretKey, $ExpectedToken, $ExtraHeader)
             $token = New-JsonWebToken -Payload $Payload -Algorithm $Algorithm -SecretKey $SecretKey -ExtraHeader $ExtraHeader
@@ -71,49 +70,49 @@ Describe 'JsonWebToken Tests' {
 
         It "<Title>" -TestCases @(
             @{
-                Payload = $payload
-                Algorithm = 'RS256'
+                Payload         = $payload
+                Algorithm       = 'RS256'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'RS256', 'certificate.p12')
-                ExpectedToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.ZOxrVs28s77vMjjcUa-Bb11Q6ZRP1IEpl8Wqkkmxa8WXNWNMKfGKSopWfWr5t-_MWgaTyGbT40SlcwvWzoBsi0y20ESuw4_gHL8-AKx7NrkFONJudhUICf95cyKN6AgyU-KZj_oFK3kyRoPtn3IqCVKdBA8xqNJGj2K0RBVkbHOw5hIxKUAak5ZJ5BiXQrGj9FUeMdBJphKf-pFORLXVxTCACe6n0djCsjHFZiNbLRS2e7r2D-lC84ff6x4-8exe55-PXfsu7IyrAEw71oyfIa1WXeCs5QaTREJ6DmohDs1f0tne8HP7FwE-mbP0JAF5ujk_pEBXX9uqvsLvM_GmjQ'
-                Title = 'Should return expected JWT token using RS256 algorithm and certificate with no headers'
+                ExpectedToken   = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.ZOxrVs28s77vMjjcUa-Bb11Q6ZRP1IEpl8Wqkkmxa8WXNWNMKfGKSopWfWr5t-_MWgaTyGbT40SlcwvWzoBsi0y20ESuw4_gHL8-AKx7NrkFONJudhUICf95cyKN6AgyU-KZj_oFK3kyRoPtn3IqCVKdBA8xqNJGj2K0RBVkbHOw5hIxKUAak5ZJ5BiXQrGj9FUeMdBJphKf-pFORLXVxTCACe6n0djCsjHFZiNbLRS2e7r2D-lC84ff6x4-8exe55-PXfsu7IyrAEw71oyfIa1WXeCs5QaTREJ6DmohDs1f0tne8HP7FwE-mbP0JAF5ujk_pEBXX9uqvsLvM_GmjQ'
+                Title           = 'Should return expected JWT token using RS256 algorithm and certificate with no headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'RS256'
+                Payload         = $payload
+                Algorithm       = 'RS256'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'RS256', 'certificate.p12')
-                ExpectedToken = 'eyJhbGciOiJSUzI1NiIsImV4cCI6MTMwMDgxOTM4MH0.eyJhIjoiYiJ9.lvtcs4C6fwDBj_YaW53LOFsvqxfnRgMUEs6rUV6NUj3gMIfRlTmSoYDk8wpw-w4xKXCacSK0gh60T_iJkHu2lWGW9X6tmvfVQhWzdKnUWspLPYH3f3KDQYB6ZT4wmhEkK3nvNZHIE-DJkE0IRFm0R22Ux2CbgzU7niHoJVOzflIp1yM2X59GfkLMsfgDtt_3d55fewHfK1dJUMKX_QEwf0888FIp1s0idg5H-xzGMRJ_tvTpVMY1ASc21RJRrdAfPVYej7phPQom8qd_bjOqCgDYNIVylCIdz-a_5dbFJsq0z5U0vAQP0_UEADUKyxY3C7cqTzqkckVTBLgNOIl6Lw'
-                ExtraHeader = $header
-                Title = 'Should return expected JWT token using RS256 algorithm and certificate with headers'
+                ExpectedToken   = 'eyJhbGciOiJSUzI1NiIsImV4cCI6MTMwMDgxOTM4MH0.eyJhIjoiYiJ9.lvtcs4C6fwDBj_YaW53LOFsvqxfnRgMUEs6rUV6NUj3gMIfRlTmSoYDk8wpw-w4xKXCacSK0gh60T_iJkHu2lWGW9X6tmvfVQhWzdKnUWspLPYH3f3KDQYB6ZT4wmhEkK3nvNZHIE-DJkE0IRFm0R22Ux2CbgzU7niHoJVOzflIp1yM2X59GfkLMsfgDtt_3d55fewHfK1dJUMKX_QEwf0888FIp1s0idg5H-xzGMRJ_tvTpVMY1ASc21RJRrdAfPVYej7phPQom8qd_bjOqCgDYNIVylCIdz-a_5dbFJsq0z5U0vAQP0_UEADUKyxY3C7cqTzqkckVTBLgNOIl6Lw'
+                ExtraHeader     = $header
+                Title           = 'Should return expected JWT token using RS256 algorithm and certificate with headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'RS384'
+                Payload         = $payload
+                Algorithm       = 'RS384'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'RS384', 'certificate.p12')
-                ExpectedToken = 'eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.B1zYb0RBU6KH4eXkv7jR3MOqcmM0f7H297lfK0-p8n95iYoW2-IDbPHSLzjCTt2W4wAgwVtZxjsGmDvUT9JooRTdWAb9DOekXAM90VBPM_VLV1JI_TcZNDmbMhrDHIhFu34KSMv_TPfzbxqkpPgmDxHKtRecajc9FrClICYAdYyqZ8NhHdpoxtyn_jHns0rbt0JZUxYnStHftmRD3imN5pfFqL14cpkGf7o3v61jXeRGu9pN_62Am9FrGOpodxNXLNRmDWQYv_EXeJu0o3iWiYAJD-P96ktrLIKYcd31X3s42FZcvFvL8tMxJia1Xs9x8keR8JZpbY4Pz-vO4xqGAi3lCitx4Q1HOzbpCoC0JaLx03r2uN4AlNjq8FZeVzSY5dFBLpJcj02ELr6QgKCXkXY32OGNBs6fVqa1EE3jPAncu-SI4702aQnhz84eIGnewlxEbnbluLLbQ-nOr55CRNhYdcpeX1i76_2Kp7A3P_HGlTJylBuHdtZ-kDvU_bYf'
-                Title = 'Should return expected JWT token using RS384 algorithm and certificate with no headers'
+                ExpectedToken   = 'eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.B1zYb0RBU6KH4eXkv7jR3MOqcmM0f7H297lfK0-p8n95iYoW2-IDbPHSLzjCTt2W4wAgwVtZxjsGmDvUT9JooRTdWAb9DOekXAM90VBPM_VLV1JI_TcZNDmbMhrDHIhFu34KSMv_TPfzbxqkpPgmDxHKtRecajc9FrClICYAdYyqZ8NhHdpoxtyn_jHns0rbt0JZUxYnStHftmRD3imN5pfFqL14cpkGf7o3v61jXeRGu9pN_62Am9FrGOpodxNXLNRmDWQYv_EXeJu0o3iWiYAJD-P96ktrLIKYcd31X3s42FZcvFvL8tMxJia1Xs9x8keR8JZpbY4Pz-vO4xqGAi3lCitx4Q1HOzbpCoC0JaLx03r2uN4AlNjq8FZeVzSY5dFBLpJcj02ELr6QgKCXkXY32OGNBs6fVqa1EE3jPAncu-SI4702aQnhz84eIGnewlxEbnbluLLbQ-nOr55CRNhYdcpeX1i76_2Kp7A3P_HGlTJylBuHdtZ-kDvU_bYf'
+                Title           = 'Should return expected JWT token using RS384 algorithm and certificate with no headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'RS384'
+                Payload         = $payload
+                Algorithm       = 'RS384'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'RS384', 'certificate.p12')
-                ExpectedToken = 'eyJhbGciOiJSUzM4NCIsImV4cCI6MTMwMDgxOTM4MH0.eyJhIjoiYiJ9.QNSAErGq5NQcMM_qG48c4VyFYnXkALp5cXsottAA-svVjTDglRM5L1fa8v8xQcH2-ef1Vcl0vexs3PPDzNsomo1DAijwNhqFH_vV9spGaUzAPGgwFkgA9F4gryJlfZotdx-f7-WJg4eAwyJ1-MNfkI4B7aLFnhXSlzNo6SbrcfGzXR4G71EbQvGz-ZD4Rj4C6zqyJ1SJ24XDnGEcH4aIVYysN0zzo4LrifNvNY-ZsGeIibTmMPvkyJosmP61YV6y0oeHciqUn2x84pbNKgm6KgMILYgFNFxwC3j1QrIYKJ-dhUU8U2rxTm_LZgaqkjJGkraQU_cLvwIbQ4zFSqbPZ2JGJZTrEdicMs1B83ymL98suA6_YiTwH1uMM6UtZDeYgBZhhdirkqo2UoP_lOdt12UinneyiQmzNxj9YZSJJWxzVTHFo0WSadqleM8QTk95-w6ciTa6RsZ3lrSytspA7K38gnNvxIp29_hTQjrFZFulC7777iD-vgDwP6ICRR8V'
-                ExtraHeader = $header
-                Title = 'Should return expected JWT token using RS384 algorithm and certificate with headers'
+                ExpectedToken   = 'eyJhbGciOiJSUzM4NCIsImV4cCI6MTMwMDgxOTM4MH0.eyJhIjoiYiJ9.QNSAErGq5NQcMM_qG48c4VyFYnXkALp5cXsottAA-svVjTDglRM5L1fa8v8xQcH2-ef1Vcl0vexs3PPDzNsomo1DAijwNhqFH_vV9spGaUzAPGgwFkgA9F4gryJlfZotdx-f7-WJg4eAwyJ1-MNfkI4B7aLFnhXSlzNo6SbrcfGzXR4G71EbQvGz-ZD4Rj4C6zqyJ1SJ24XDnGEcH4aIVYysN0zzo4LrifNvNY-ZsGeIibTmMPvkyJosmP61YV6y0oeHciqUn2x84pbNKgm6KgMILYgFNFxwC3j1QrIYKJ-dhUU8U2rxTm_LZgaqkjJGkraQU_cLvwIbQ4zFSqbPZ2JGJZTrEdicMs1B83ymL98suA6_YiTwH1uMM6UtZDeYgBZhhdirkqo2UoP_lOdt12UinneyiQmzNxj9YZSJJWxzVTHFo0WSadqleM8QTk95-w6ciTa6RsZ3lrSytspA7K38gnNvxIp29_hTQjrFZFulC7777iD-vgDwP6ICRR8V'
+                ExtraHeader     = $header
+                Title           = 'Should return expected JWT token using RS384 algorithm and certificate with headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'RS512'
+                Payload         = $payload
+                Algorithm       = 'RS512'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'RS512', 'certificate.p12')
-                ExpectedToken = 'eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.MTAlqVHm3xXIX7hcTgSvxPTFxZeCLTbt7sGOyw9jde7JRpVq_QNg6IfcsDNwrwvjY42sIXiq7eZa6L5AQ-HkZZ4GirgmcBQdEt1R44sY9rIdEhw_67K1fj2LnJB-n28fhJfXZsTZjcIBMTswLtAJMRhz56i7nXm4Fepy-bzqKtP841u5veQCeAlGYzsFqLAdxDnpzpgWlAyRx1Il835I5bnAZ6iGVeslpH5IbWymrrsOETLj8QxOHJrFXakoZVn980ug3zIMTMe3MmiD2ribHdUsEhMrVBcUlhaBHuV3cwCBx3Aw7curtOeoUWdA43zw4R9c-FCrWmKlDj5qcFCJfvZTUN-gO6pSUt1Gp-4E5XgkbjP4GcRvoPMwuwSFPqs-cZ3uyFBGI1hWxytx1Q7C1gR_XW6V6B0G9eCaekyfVOpDCswBpI_TOEFTV4fEym7RDyTQq1tvF0Jc74cVuHUncHG1GopVGlHHRCQJI4km1MjE6ArOpzF8S7HdCthkhMEsVvUpQs7jQBwFOlISSm1on8Rd1aQkZRhxddmipLQh8fQqK_oXhtWpnJNybMi5eThlD6mf1O7feX4K3C_b5xmaZi-FU_Gf4J8Z1Na1h9umXCH7c2uZ_NzpY10kFAwEPL3lFspc8pCzrafC4-fyc6L6na9cE7xvBO-XsCBc-vX8Pro'
-                Title = 'Should return expected JWT token using RS512 algorithm and certificate with no headers'
+                ExpectedToken   = 'eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.MTAlqVHm3xXIX7hcTgSvxPTFxZeCLTbt7sGOyw9jde7JRpVq_QNg6IfcsDNwrwvjY42sIXiq7eZa6L5AQ-HkZZ4GirgmcBQdEt1R44sY9rIdEhw_67K1fj2LnJB-n28fhJfXZsTZjcIBMTswLtAJMRhz56i7nXm4Fepy-bzqKtP841u5veQCeAlGYzsFqLAdxDnpzpgWlAyRx1Il835I5bnAZ6iGVeslpH5IbWymrrsOETLj8QxOHJrFXakoZVn980ug3zIMTMe3MmiD2ribHdUsEhMrVBcUlhaBHuV3cwCBx3Aw7curtOeoUWdA43zw4R9c-FCrWmKlDj5qcFCJfvZTUN-gO6pSUt1Gp-4E5XgkbjP4GcRvoPMwuwSFPqs-cZ3uyFBGI1hWxytx1Q7C1gR_XW6V6B0G9eCaekyfVOpDCswBpI_TOEFTV4fEym7RDyTQq1tvF0Jc74cVuHUncHG1GopVGlHHRCQJI4km1MjE6ArOpzF8S7HdCthkhMEsVvUpQs7jQBwFOlISSm1on8Rd1aQkZRhxddmipLQh8fQqK_oXhtWpnJNybMi5eThlD6mf1O7feX4K3C_b5xmaZi-FU_Gf4J8Z1Na1h9umXCH7c2uZ_NzpY10kFAwEPL3lFspc8pCzrafC4-fyc6L6na9cE7xvBO-XsCBc-vX8Pro'
+                Title           = 'Should return expected JWT token using RS512 algorithm and certificate with no headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'RS512'
+                Payload         = $payload
+                Algorithm       = 'RS512'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'RS512', 'certificate.p12')
-                ExpectedToken = 'eyJhbGciOiJSUzUxMiIsImV4cCI6MTMwMDgxOTM4MH0.eyJhIjoiYiJ9.TfcwNV4WOcDLJ6bRYabyGOtWVSm3SGPNSdDyCIsiCvXaJKMHsvrB09mbJjuGF2uMYeQcJbwfP3Wd8-rBam2-I0tbbD8WHozAxPgVRnVZeCoUgurRgtgVZ1mtvAt40vt9aYWY0-s4UJj8W5_SoFL6EgOdNPvzyU9CdBU-r5R4o1UzK4_viBLQ8eSj828aVSJS2o4EHw_vUAYobxE0HR243qzCVr3Ob_OZ7uv9-igGXgbmFahqdtIJrioueU9cnER3VJbVEQFWMFxZL0HdJklGtov_DXFxfOJHrOXjEtG3nIpIfytbdErKYqJBtU-w22Zrb-KBHwAtL5Rw9apypce9iuL9xu6yG2_7tyEa_JrdGWtXyVm7TdBePAnzCskc-xHsz67E22lVgDGhyfo4_fx36Fjm8xPoELat3dk8XgFI3XAAdMnk2A92qmFEwfEN2Af0Bws3SInXP4rQ8-gPK9ycZ_p9OVaUQtesI4tlSEHpN4motZyh-HrsuzeiUuW2IsTbc2UpR2Cuf34B8YJyNKNAoRfcCBcxDreCbF5HLCOrumNX7czEmQ1kaIPXIFt4mqAW8S8IgG24L5v4632IF-GpkK72GfwBdY7Tq39wYfOKoYNh96lX0MmfYCxmrXG7pKEH2tr9fpWeUXrMXWKA1Q7FOwUlAFJFLlKYeIa9W3TJlkc'
-                ExtraHeader = $header
-                Title = 'Should return expected JWT token using RS512 algorithm and certificate with headers'
+                ExpectedToken   = 'eyJhbGciOiJSUzUxMiIsImV4cCI6MTMwMDgxOTM4MH0.eyJhIjoiYiJ9.TfcwNV4WOcDLJ6bRYabyGOtWVSm3SGPNSdDyCIsiCvXaJKMHsvrB09mbJjuGF2uMYeQcJbwfP3Wd8-rBam2-I0tbbD8WHozAxPgVRnVZeCoUgurRgtgVZ1mtvAt40vt9aYWY0-s4UJj8W5_SoFL6EgOdNPvzyU9CdBU-r5R4o1UzK4_viBLQ8eSj828aVSJS2o4EHw_vUAYobxE0HR243qzCVr3Ob_OZ7uv9-igGXgbmFahqdtIJrioueU9cnER3VJbVEQFWMFxZL0HdJklGtov_DXFxfOJHrOXjEtG3nIpIfytbdErKYqJBtU-w22Zrb-KBHwAtL5Rw9apypce9iuL9xu6yG2_7tyEa_JrdGWtXyVm7TdBePAnzCskc-xHsz67E22lVgDGhyfo4_fx36Fjm8xPoELat3dk8XgFI3XAAdMnk2A92qmFEwfEN2Af0Bws3SInXP4rQ8-gPK9ycZ_p9OVaUQtesI4tlSEHpN4motZyh-HrsuzeiUuW2IsTbc2UpR2Cuf34B8YJyNKNAoRfcCBcxDreCbF5HLCOrumNX7czEmQ1kaIPXIFt4mqAW8S8IgG24L5v4632IF-GpkK72GfwBdY7Tq39wYfOKoYNh96lX0MmfYCxmrXG7pKEH2tr9fpWeUXrMXWKA1Q7FOwUlAFJFLlKYeIa9W3TJlkc'
+                ExtraHeader     = $header
+                Title           = 'Should return expected JWT token using RS512 algorithm and certificate with headers'
             }
         ) {
             param($Payload, $Algorithm, $CertificatePath, $ExpectedToken, $ExtraHeader)
@@ -129,43 +128,43 @@ Describe 'JsonWebToken Tests' {
 
         It "<Title>" -TestCases @(
             @{
-                Payload = $payload
-                Algorithm = 'ES256'
+                Payload         = $payload
+                Algorithm       = 'ES256'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'ES256', 'certificate.pfx')
-                Title = 'Should return a valid JWT token using ES256 algorithm and certificate with no headers'
+                Title           = 'Should return a valid JWT token using ES256 algorithm and certificate with no headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'ES256'
+                Payload         = $payload
+                Algorithm       = 'ES256'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'ES256', 'certificate.pfx')
-                ExtraHeader = $header
-                Title = 'Should return a valid JWT token using ES256 algorithm and certificate with headers'
+                ExtraHeader     = $header
+                Title           = 'Should return a valid JWT token using ES256 algorithm and certificate with headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'ES384'
+                Payload         = $payload
+                Algorithm       = 'ES384'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'ES384', 'certificate.pfx')
-                Title = 'Should return a valid JWT token using ES384 algorithm and certificate with no headers'
+                Title           = 'Should return a valid JWT token using ES384 algorithm and certificate with no headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'ES384'
+                Payload         = $payload
+                Algorithm       = 'ES384'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'ES384', 'certificate.pfx')
-                ExtraHeader = $header
-                Title = 'Should return a valid JWT token using ES384 algorithm and certificate with headers'
+                ExtraHeader     = $header
+                Title           = 'Should return a valid JWT token using ES384 algorithm and certificate with headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'ES512'
+                Payload         = $payload
+                Algorithm       = 'ES512'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'ES512', 'certificate.pfx')
-                Title = 'Should return a valid JWT token using ES512 algorithm and certificate with no headers'
+                Title           = 'Should return a valid JWT token using ES512 algorithm and certificate with no headers'
             }
             @{
-                Payload = $payload
-                Algorithm = 'ES512'
+                Payload         = $payload
+                Algorithm       = 'ES512'
                 CertificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'ES512', 'certificate.pfx')
-                ExtraHeader = $header
-                Title = 'Should return a valid JWT token using ES512 algorithm and certificate with headers'
+                ExtraHeader     = $header
+                Title           = 'Should return a valid JWT token using ES512 algorithm and certificate with headers'
             }
         ) {
             param($Payload, $Algorithm, $CertificatePath, $ExtraHeader)
@@ -175,6 +174,50 @@ Describe 'JsonWebToken Tests' {
             $token = New-JsonWebToken -Payload $Payload -Algorithm $Algorithm -Certificate $x509Certificate -ExtraHeader $ExtraHeader
             $validToken = Test-JsonWebToken -Token $token -Certificate $x509Certificate -Algorithm $Algorithm
             $validToken | Should -BeTrue
+        }
+    }
+
+    Context 'None Algorithm' {
+        BeforeAll {
+            $algorithm = 'none'
+            $payload = @{ 'a' = 'b' }
+        }
+
+        It 'Should return valid JWT token using none algorithm without headers and output warning' {
+            $token = New-JsonWebToken -Payload $payload -Algorithm $algorithm -WarningVariable warning1 -WarningAction SilentlyContinue
+            $validToken = Test-JsonWebToken -Token $token -Algorithm $algorithm -WarningVariable warning2 -WarningAction SilentlyContinue
+            $validToken | Should -BeTrue
+            $warning1 | Should -HaveCount 1
+            $warning2 | Should -HaveCount 1
+        }
+
+        It 'Should return valid JWT token using none algorithm with headers output warning' {
+            $token = New-JsonWebToken -Payload $payload -Algorithm $algorithm -ExtraHeader $headers -WarningVariable warning1 -WarningAction SilentlyContinue
+            $validToken = Test-JsonWebToken -Token $token -Algorithm $algorithm -WarningVariable warning2 -WarningAction SilentlyContinue
+            $validToken | Should -BeTrue
+            $warning1 | Should -HaveCount 1
+            $warning2 | Should -HaveCount 1
+        }
+    }
+
+    Context 'Invalid Parameter Combinations' {
+        BeforeAll {
+            $payload = @{ 'a' = 'b' }
+            $secretKey = 'abc' | ConvertTo-SecureString -AsPlainText -Force
+            $certificatePath = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Certificates' -AdditionalChildPath 'RS256', 'certificate.p12')
+            $x509Certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($certificatePath)
+        }
+
+        It 'Should throw an exception if incompatible algorithm RS256 is used with -SecretKey' {
+            { New-JsonWebToken -Payload $payload -Algorithm 'RS256' -SecretKey $secretKey } | Should -Throw -ErrorId 'SecretRequiredAlgorithms,PoshJsonWebToken.Commands.NewJsonWebTokenCommand'
+        }
+
+        It 'Should throw an exception if incompatible algorithm HS256 is used with -Certificate' {
+            { New-JsonWebToken -Payload $payload -Algorithm 'HS256' -Certificate $x509Certificate } | Should -Throw -ErrorId 'CertificateRequiredAlgorithms,PoshJsonWebToken.Commands.NewJsonWebTokenCommand'
+        }
+
+        It 'Should throw an exception if algorithm is used without -SecretKey or -Certificate parameter' {
+            { New-JsonWebToken -Payload $payload -Algorithm 'HS256' } | Should -Throw -ErrorId 'AlgorithmRequiresKey,PoshJsonWebToken.Commands.NewJsonWebTokenCommand'
         }
     }
 }


### PR DESCRIPTION
Fixes #7.

What changed:
+ Added `None` parameter set for generating unprotect tokens. 
+ A warning is displayed if `none` algorithm is used: `Using NONE (unprotected) plain text algorithm without integrity protection.`
+ Tests updated
+ Docs updated with warning and parameter set.
+ Formating changes added to make things a little more consistent. 
+ Fixed VSCode task to work with new `InvokeBuild` module.