### PR TITLE
Exclude PS256, PS384 & PS512 algorithms

### DIFF
--- a/src/Common/AlgorithmHelpers.cs
+++ b/src/Common/AlgorithmHelpers.cs
@@ -131,5 +131,18 @@ internal static class AlgorithmHelpers
     /// <param name="jwsAlgorithm">The parsed JWS algorithm.</param>
     /// <returns>Boolean if parsing was successful.</returns>
     internal static bool TryParseJwsAlgorithm(string algorithm, out JwsAlgorithm jwsAlgorithm)
-        => Enum.TryParse(algorithm, ignoreCase: true, out jwsAlgorithm);
+    {
+        if (Enum.TryParse(algorithm, ignoreCase: true, out jwsAlgorithm))
+        {
+            // Exclude PS* algorithms since they are unsupported in this module.
+            if (jwsAlgorithm is JwsAlgorithm.PS256 or JwsAlgorithm.PS384 or JwsAlgorithm.PS512)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/test/JsonWebToken.Tests.ps1
+++ b/test/JsonWebToken.Tests.ps1
@@ -233,11 +233,25 @@ Describe 'JsonWebToken Tests' {
             | Should -Throw -ErrorId 'AlgorithmRequiresKey,PoshJsonWebToken.Commands.TestJsonWebTokenCommand'
         }
 
-        It 'Show throw an exception if algorithm is invalid' {
+        It 'Should throw an exception if algorithm is invalid' {
             { New-JsonWebToken -Payload $payload -Algorithm 'Invalid' }
             | Should -Throw -ErrorId 'InvalidAlgorithm,PoshJsonWebToken.Commands.NewJsonWebTokenCommand'
 
             { Test-JsonWebToken -Token $token -Algorithm 'Invalid' }
+            | Should -Throw -ErrorId 'InvalidAlgorithm,PoshJsonWebToken.Commands.TestJsonWebTokenCommand'
+        }
+
+        It "Should throw an exception if '<Algorithm>' algorithm is used" -TestCases @(
+            @{ Algorithm = 'PS256' }
+            @{ Algorithm = 'PS384' }
+            @{ Algorithm = 'PS512' }
+        ) {
+            param($Algorithm)
+
+            { New-JsonWebToken -Payload $payload -Algorithm $Algorithm }
+            | Should -Throw -ErrorId 'InvalidAlgorithm,PoshJsonWebToken.Commands.NewJsonWebTokenCommand'
+
+            { Test-JsonWebToken -Token $token -Algorithm $Algorithm }
             | Should -Throw -ErrorId 'InvalidAlgorithm,PoshJsonWebToken.Commands.TestJsonWebTokenCommand'
         }
     }


### PR DESCRIPTION
Related to #6.

Until a solution is found to support PS256, PS384 & PS512 algorithms, going to exclude it from parsing of `JwsAlgorithm` when set with `-Algorithm` parameter.