### PR TITLE
Fix Encryption parameter sets and included build task for updating markdown

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,5 +4,7 @@
     "MD013": {
         "line_length": 240
     },
-    "MD040": false
+    "MD040": false,
+    "MD022": false,
+    "MD031": false
 }

--- a/build.ps1
+++ b/build.ps1
@@ -6,7 +6,7 @@ param (
     $Configuration = 'Debug',
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet('Build', 'Test')]
+    [ValidateSet('Build', 'Test', 'Docs')]
     [string]
     $Task = 'Build'
 )

--- a/docs/en-US/New-JsonWebToken.md
+++ b/docs/en-US/New-JsonWebToken.md
@@ -14,24 +14,20 @@ Creates a signed or encrypted Json Web Token (JWT).
 ## SYNTAX
 
 ### SecretKey
-
 ```
 New-JsonWebToken -Payload <Hashtable> [-ExtraHeader <Hashtable>] -Algorithm <String> [-Encryption <String>]
  -SecretKey <SecureString> [<CommonParameters>]
 ```
 
 ### Certificate
-
 ```
 New-JsonWebToken -Payload <Hashtable> [-ExtraHeader <Hashtable>] -Algorithm <String> [-Encryption <String>]
- -Certificate <X509Certificate2> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ -Certificate <X509Certificate2> [<CommonParameters>]
 ```
 
 ### None
-
 ```
-New-JsonWebToken -Payload <Hashtable> [-ExtraHeader <Hashtable>] -Algorithm <String> [-Encryption <String>]
- [<CommonParameters>]
+New-JsonWebToken -Payload <Hashtable> [-ExtraHeader <Hashtable>] -Algorithm <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -140,6 +136,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Encryption
+
+The encryption used for JWE (Json Web Encryption) JWT tokens.
+
+```yaml
+Type: String
+Parameter Sets: SecretKey, Certificate
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ExtraHeader
 
 The extra headers needed to sign JWT token.
@@ -208,24 +220,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Encryption
-
-The encryption used for JWE (Json Web Encryption) JWT tokens.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
 For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 

--- a/docs/en-US/Test-JsonWebToken.md
+++ b/docs/en-US/Test-JsonWebToken.md
@@ -14,24 +14,20 @@ Tests signed or encrypted Json Web Token (JWT) is valid.
 ## SYNTAX
 
 ### SecretKey
-
 ```
 Test-JsonWebToken -Token <SecureString> -Algorithm <String> [-Encryption <String>] -SecretKey <SecureString>
  [<CommonParameters>]
 ```
 
 ### Certificate
-
 ```
 Test-JsonWebToken -Token <SecureString> -Algorithm <String> [-Encryption <String>]
  -Certificate <X509Certificate2> [<CommonParameters>]
 ```
 
 ### None
-
 ```
-Test-JsonWebToken -Token <SecureString> -Algorithm <String> [-Encryption <String>]
- [<CommonParameters>]
+Test-JsonWebToken -Token <SecureString> -Algorithm <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -149,6 +145,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Encryption
+
+The encryption used for JWE (Json Web Encryption) JWT tokens.
+
+```yaml
+Type: String
+Parameter Sets: SecretKey, Certificate
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -SecretKey
 
 The secret secret key used for signing or encryption.
@@ -194,22 +206,6 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Encryption
-
-The encryption used for JWE (Json Web Encryption) JWT tokens.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/src/Commands/JsonWebTokenBaseCommand.cs
+++ b/src/Commands/JsonWebTokenBaseCommand.cs
@@ -33,7 +33,8 @@ public abstract class JsonWebTokenCommandBase : PSCmdlet
     [ArgumentCompleter(typeof(AlgorithmCompleter))]
     public string Algorithm { get; set; }
 
-    [Parameter(Mandatory = false)]
+    [Parameter(Mandatory = false, ParameterSetName = SecretKeyParameterSet)]
+    [Parameter(Mandatory = false, ParameterSetName = CertificateParameterSet)]
     [ArgumentCompleter(typeof(EncryptionCompleter))]
     public string Encryption { get; set; }
 


### PR DESCRIPTION
Set `-Encryption` parameter to use `SecretKey` and `Certificate` parameter sets only.

Also included build task `Docs` to update markdown automatically and include workaround for removing `-ProgressAction` common parameter everytime.