### PR TITLE
Add compression switch parameter to New-JsonWebToken cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### General Cmdlet Updates and Fixes
+
++ Add compression switch parameter to New-JsonWebToken cmdlet (#24).
+  + Added `-Compression` switch to `New-JsonWebToken` cmdlet.
+  + Compresses payload before encryption.
+
+### Documentation and Help Content
+
++ Add PS Gallery version badge (#28).
+
 ## v1.1.1 - 05/02/2024
 
 ### General Cmdlet Updates and Fixes

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ While there are a few other JWT PowerShell modules on the gallery this module in
     + `A128GCMKW`, `A192GCMKW`, `A256GCMKW` (AES GCM Key Wrap) encryption with `A128CBC_HS256`, `A192CBC_HS384`, `A256CBC_HS512`, `A128GCM`, `A192GCM`, `A256GCM`.
     + `PBES2_HS256_A128KW`, `PBES2_HS384_A192KW`, `PBES2_HS512_A256KW` (Password-Based Encryption Scheme 2) with `A128CBC_HS256`, `A192CBC_HS384`, `A256CBC_HS512`, `A128GCM`, `A192GCM`, `A256GCM`.
 
+  + Compression
+
+    + `DEF` (DEFLATE) compression.
+
 + Uses the ultimate [`jose-jwt`](https://www.nuget.org/packages/jose-jwt/) nuget package to get a wide variety of builtin JWT support into PowerShell.
 
 ## Requirements

--- a/docs/en-US/New-JsonWebToken.md
+++ b/docs/en-US/New-JsonWebToken.md
@@ -15,14 +15,14 @@ Creates a signed or encrypted Json Web Token (JWT).
 
 ### SecretKey
 ```
-New-JsonWebToken -Payload <Hashtable> [-ExtraHeader <Hashtable>] -Algorithm <String> [-Encryption <String>]
- -SecretKey <SecureString> [<CommonParameters>]
+New-JsonWebToken -Payload <Hashtable> [-ExtraHeader <Hashtable>] [-Compression] -Algorithm <String>
+ [-Encryption <String>] -SecretKey <SecureString> [<CommonParameters>]
 ```
 
 ### Certificate
 ```
-New-JsonWebToken -Payload <Hashtable> [-ExtraHeader <Hashtable>] -Algorithm <String> [-Encryption <String>]
- -Certificate <X509Certificate2> [<CommonParameters>]
+New-JsonWebToken -Payload <Hashtable> [-ExtraHeader <Hashtable>] [-Compression] -Algorithm <String>
+ [-Encryption <String>] -Certificate <X509Certificate2> [<CommonParameters>]
 ```
 
 ### None
@@ -214,6 +214,22 @@ Parameter Sets: SecretKey
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Compression
+
+The switch to compress payload before encryption.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: SecretKey, Certificate
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/src/Common/AlgorithmHelpers.cs
+++ b/src/Common/AlgorithmHelpers.cs
@@ -135,6 +135,32 @@ internal static class AlgorithmHelpers
     }
 
     /// <summary>
+    /// Throws exception if compression is not used with JWE encryption.
+    /// </summary>
+    /// <param name="cmdlet">The cmdlet.</param>
+    /// <param name="compression">The compression switch parameter.</param>
+    internal static void ReportCompressionRequiresJweEncryption(PSCmdlet cmdlet, SwitchParameter compression)
+    {
+        var encryptions = string.Join(
+            ",",
+            JweEncryption.A128CBC_HS256,
+            JweEncryption.A192CBC_HS384,
+            JweEncryption.A256CBC_HS512,
+            JweEncryption.A128GCM,
+            JweEncryption.A192GCM,
+            JweEncryption.A256GCM);
+
+        var errorMessage = string.Format(AlgorithmStrings.CompressionRequiresJweEncryption, encryptions);
+        var exception = new ArgumentException(errorMessage);
+        var errorRecord = new ErrorRecord(
+            exception,
+            nameof(AlgorithmStrings.CompressionRequiresJweEncryption),
+            ErrorCategory.InvalidArgument,
+            compression);
+        cmdlet.ThrowTerminatingError(errorRecord);
+    }
+
+    /// <summary>
     /// Throws expection if incorrect JWE algorithm is used with secret key.
     /// </summary>
     /// <param name="cmdlet">The cmdlet.</param>

--- a/src/Resources/AlgorithmStrings.Designer.cs
+++ b/src/Resources/AlgorithmStrings.Designer.cs
@@ -92,6 +92,17 @@ namespace PoshJsonWebToken.Resources
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Compression parameter requires any one of &apos;{0}&apos; JWE encryptions..
+        /// </summary>
+        internal static string CompressionRequiresJweEncryption
+        {
+            get
+            {
+                return ResourceManager.GetString("CompressionRequiresJweEncryption", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Algorithm parameter requires any one of &apos;{0}&apos; algorithms..
         /// </summary>
         internal static string InvalidAlgorithm

--- a/src/Resources/AlgorithmStrings.resx
+++ b/src/Resources/AlgorithmStrings.resx
@@ -144,4 +144,7 @@
   <data name="SecretRequiredJweAlgorithms" xml:space="preserve">
     <value>Secret parameter requires any one of '{0}' JWE algorithms.</value>
   </data>
+  <data name="CompressionRequiresJweEncryption" xml:space="preserve">
+    <value>Compression parameter requires any one of '{0}' JWE encryptions.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #24

Adds `-Compression` switch to `New-JsonWebToken` cmdlet.